### PR TITLE
(feat) Add moment.js on chat

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "angular": "~1.3.16",
     "angular-route": "~1.3.16",
-    "angular-socket-io": "^0.7.0"
+    "angular-socket-io": "^0.7.0",
+    "moment": "^2.13.0"
   }
 }

--- a/client/app.js
+++ b/client/app.js
@@ -7,7 +7,8 @@ angular.module('roadtrippin', [
   'roadtrippin.home',
   'roadtrippin.auth',
   'roadtrippin.authFactory',
-  'ui.router'
+  'ui.router',
+  'angularMoment'
 ])
 
 .config(function ($stateProvider, $urlRouterProvider, $httpProvider) {

--- a/client/index.html
+++ b/client/index.html
@@ -16,6 +16,8 @@
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js"></script>
   <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.4.5/angular.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/angular-ui-router/0.2.18/angular-ui-router.js"></script>
+  <script src="https://cdn.jsdelivr.net/momentjs/2.13.0/moment.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/angular-moment/1.0.0-beta.6/angular-moment.min.js"></script>
   <!-- Socket.io -->
   <script src="/socket.io/socket.io.js"></script>
   <!-- Our resources -->

--- a/client/trip/mapCtrl.js
+++ b/client/trip/mapCtrl.js
@@ -213,7 +213,7 @@ angular.module('roadtrippin.maps', [])
     };
 
     socket.on('message saved', function(msg) {
-      // msg.time = moment().fromNow()
+      msg.time = new Date();
       $scope.messages.push(msg);
       $scope.$digest();
     });

--- a/client/trip/trip.html
+++ b/client/trip/trip.html
@@ -182,8 +182,9 @@
               </span>
               <div class="chat-body clearfix">
                 <div class="header">
-                  <strong class="primary-font">{{msg.username}}</strong><small class="pull-right text-muted">
-                    <span class="glyphicon glyphicon-time"></span>{{msg.time}}</small>
+                  <strong class="primary-font">{{msg.username}}</strong>
+                  <small class="pull-right text-muted" am-time-ago="msg.time">{{msg.time}}
+                    </small>
                 </div>
                 <p>{{msg.message}}</p>
               </div>


### PR DESCRIPTION
minor issue the time icon is showing at the left of moment.
https://www.dropbox.com/s/pbf8rb1yn4vy2bv/Screenshot%202016-04-25%2017.48.14.png?dl=0

i cant seem to get if on the right side of moment time.

either the screenshot or we can just completely get rid of time icon?
